### PR TITLE
removed authorization filters for send email and message controller

### DIFF
--- a/MessageService/Controllers/MessageController.cs
+++ b/MessageService/Controllers/MessageController.cs
@@ -14,7 +14,6 @@ namespace MessageService.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    [Authorize(Roles = "Admin, League Manager, Head Coach, Assistant Coach, Parent, Player")]
     public class MessageController : ControllerBase
     {
         private readonly Logic _logic;
@@ -131,7 +130,6 @@ namespace MessageService.Controllers
 
         [HttpPost]
         [Route("SendEmail")]
-        [Authorize]
         public async Task<ActionResult> SendEmailToUser(EmailMessage message)
         {
             await _emailSender.SendEmailAsync(message);


### PR DESCRIPTION
User creation calls the sendemail endpoint and doesn't have a token to use the endpoint